### PR TITLE
Un-enterprise community page

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -97,7 +97,7 @@
 
                </div>
                <div class="short-row center">
-                    <span class="community-span"><span class="fa fa-briefcase fico"></span>Business Inquiries</span>
+                    <span class="community-span"><span class="fa fa-briefcase fico"></span>Supporters</span>
                     <p><a href="mailto:josh@iocage.io">josh@iocage.io</a></p>
                </div>
           </div>


### PR DESCRIPTION
By renaming `Business Inquiries` to `Supporters` in Community page the project truly reflects its non-corporate structure.