### PR TITLE
point Docs link to overview page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ navigation:
   - name: "Community"
     url: "/community/"
   - name: "Docs"
-    url: "https://iocage.readthedocs.io/en/latest/index.html"
+    url: "/docs/"
   - name: "GitHub"
     url: "https://github.com/iocage"
     icon: "github"

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,28 @@
+---
+layout: iocage
+title: Docs
+---
+<div class="hero-container-simple">
+	<div class="hero">
+		<div class="row">
+			<div class="col-xs-12">
+				<h1>Documentation</h1>
+			</div>
+		</div>
+	</div>
+</div>
+<div class="container-fluid">
+	<div class="row">
+		<h2>iocage v1</h2>
+		<ul>
+			<li>[iocage v1 Docs](https://iocage.readthedocs.io/en/latest/index.html)</li>
+		</ul>
+	</div>
+	<div class="row">
+		<h2>iocage v2 (libiocage)</h2>
+		<ul>
+			<li>[iocage v2 Handbook](https://iocage.io/handbook)</li>
+			<li>[libiocage API Reference](https://iocage.io/libiocage)</li>
+		</ul>
+	</div>
+</div>


### PR DESCRIPTION
The Docs navigation item directly pointed to the readthedocs page. Instead the link points to an overview page `/docs/` that also links to the iocage v2 handbook and the libiocage API reference.